### PR TITLE
Allow for Init of an API without any endpoint parameters

### DIFF
--- a/lib/api_adaptor/base.rb
+++ b/lib/api_adaptor/base.rb
@@ -42,9 +42,9 @@ module ApiAdaptor
       @logger ||= ApiAdaptor::NullLogger.new
     end
 
-    def initialize(endpoint_url, options = {})
+    def initialize(endpoint_url = nil, options = {})
       options[:endpoint_url] = endpoint_url
-      raise InvalidAPIURL unless endpoint_url =~ URI::RFC3986_Parser::RFC3986_URI
+      raise InvalidAPIURL if !endpoint_url.nil? && endpoint_url !~ URI::RFC3986_Parser::RFC3986_URI
 
       base_options = { logger: ApiAdaptor::Base.logger }
       default_options = base_options.merge(ApiAdaptor::Base.default_options || {})

--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe ApiAdaptor::Base do
     described_class.default_options = nil
   end
 
+  it "allows initialization without parameters" do
+    expect { ConcreteApi.new }.not_to raise_error
+  end
+
   it "should construct escaped query string" do
     api = ConcreteApi.new("http://foo")
     url = api.url_for_slug("slug", "a" => " ", "b" => "/")


### PR DESCRIPTION
The wrapper works if you don't want to use the base_url feature you can just call client.get_json("http://foo.bar/json") if you want The base URL is only of value if you want to stop having to type that everywhere.

So let's make it optional