### PR TITLE
chore: Remove last GOV.UK references

### DIFF
--- a/lib/api_adaptor/response.rb
+++ b/lib/api_adaptor/response.rb
@@ -10,13 +10,12 @@ module ApiAdaptor
   # API endpoints should return absolute URLs so that they make sense outside of the
   # domain context. However on systems within an API we want to present relative URLs.
   # By specifying a base URI, this will convert all matching web_urls into relative URLs
-  # This is useful on non-canonical frontends, such as those in staging environments.
   #
   # Example:
   #
-  #   r = Response.new(response, web_urls_relative_to: "https://www.gov.uk")
+  #   r = Response.new(response, web_urls_relative_to: "https://www.example.com")
   #   r['results'][0]['web_url']
-  #   => "/bank-holidays"
+  #   => "/foo"
   class Response
     extend Forwardable
     include Enumerable


### PR DESCRIPTION
Not trying to hide the trail here, i've acknowleged all this is theft early on, but wanna make a clean break here.

I'm not affiliated when I push this code and it's a random reference otherwise