### PR TITLE
Fix CacheControl#shared_max_age directive check

### DIFF
--- a/lib/api_adaptor/response.rb
+++ b/lib/api_adaptor/response.rb
@@ -82,7 +82,10 @@ module ApiAdaptor
         self["max-age"].to_i if key?("max-age")
       end
 
-      # Returns the r-maxage (reverse max age) directive value
+      # Returns the r-maxage directive value
+      #
+      # Note: r-maxage is a non-standard Cache-Control directive and is not part
+      # of RFC 7234. This method exists for compatibility with custom cache implementations.
       #
       # @return [Integer, nil] Reverse maximum age in seconds, or nil if not present
       def reverse_max_age
@@ -92,9 +95,12 @@ module ApiAdaptor
 
       # Returns the s-maxage (shared max age) directive value
       #
+      # The s-maxage directive is like max-age but only applies to shared caches
+      # (e.g., CDNs, proxies). It overrides max-age for shared caches.
+      #
       # @return [Integer, nil] Shared maximum age in seconds, or nil if not present
       def shared_max_age
-        self["s-maxage"].to_i if key?("r-maxage")
+        self["s-maxage"].to_i if key?("s-maxage")
       end
       alias s_maxage shared_max_age
 

--- a/spec/lib/api_adaptor/json_client_spec.rb
+++ b/spec/lib/api_adaptor/json_client_spec.rb
@@ -204,7 +204,8 @@ RSpec.describe ApiAdaptor::JsonClient do
 
       it "raises HTTPClientError if the endpoint returns any other 4xx status" do
         url = "http://some.endpoint/some.json"
-        statuses = (400..499).to_a - [400, 401, 403, 404, 410, 413, 422, 429]
+        # Exclude statuses with specific handling: 400, 401, 403, 404, 408 (timeout), 410, 413, 422, 429
+        statuses = (400..499).to_a - [400, 401, 403, 404, 408, 410, 413, 422, 429]
         stub_request(:get, url).to_return(body: "{}", status: statuses.sample)
         expect { client.get_json(url) }.to(raise_error(ApiAdaptor::HTTPClientError))
       end


### PR DESCRIPTION
## Summary

Fixes #59 - Corrects bug in `Response::CacheControl#shared_max_age` and documents non-standard `r-maxage` directive.

## Changes

### Bug Fix
- **Fixed `shared_max_age`** to check for `"s-maxage"` instead of `"r-maxage"`
  - Before: `self["s-maxage"].to_i if key?("r-maxage")` ❌
  - After: `self["s-maxage"].to_i if key?("s-maxage")` ✅

### Documentation
- Added note that `r-maxage` is non-standard (not part of RFC 7234)
- Enhanced `s-maxage` documentation explaining shared cache behavior
- Clarified that s-maxage overrides max-age for CDNs/proxies

### Test Fix
- Fixed flaky test that randomly failed when 408 status was sampled
- Excluded 408 from random test data (handled specially as timeout)

## Impact

- **Low severity**: Neither method currently used in codebase
- **No breaking changes**: API surface unchanged
- **Correctness**: `shared_max_age` will now work correctly if used

## Verification

- ✅ All 153 tests passing
- ✅ RuboCop: no offenses
- ✅ Coverage maintained: 92.31% line, 81.65% branch

## Credit

Discovered by GitHub Copilot during v1.0.0 documentation review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)