### PR TITLE
Fix docs workflow: use Ruby 3.4 instead of 4.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
-          ruby-version: "4.0"
+          ruby-version: "3.4"
           bundler-cache: true
 
       - name: Generate YARD documentation


### PR DESCRIPTION
## Problem

YARD documentation build is failing on main with:
```
LoadError: cannot load such file -- irb/notifier
```

## Root Cause

Ruby 4.0 removed `irb/notifier` which YARD 0.9.38 depends on. Ruby 4.0 is still in preview and many gems haven't caught up yet.

## Solution

Change docs.yml workflow to use Ruby 3.4 (latest stable) instead of Ruby 4.0.

## Impact

- ✅ Fixes YARD documentation generation
- ✅ No code changes, CI only
- ✅ Unblocks v1.0.0 release docs deployment

## Testing

Will verify docs workflow passes after merge.