### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.1] - 2026-05-31
+
+### Changed
+- Updated bundled gem dependencies to their latest compatible versions, including addressable, bigdecimal, json, rake, rubocop, timecop, webmock, and yard.
+- Updated GitHub Actions dependencies, including ruby/setup-ruby v1.300.0, rubygems/release-gem v1.2.0, actions/deploy-pages v5.0.0, and refreshed CodeQL action pins.
+- Use Ruby 3.4 for YARD documentation generation to keep docs builds compatible with the current toolchain.
+
 ## [1.0.0] - 2026-02-15
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    api_adaptor (1.0.0)
+    api_adaptor (1.0.1)
       addressable (~> 2.8)
       base64 (~> 0.3)
       bigdecimal (>= 3.3, < 5.0)

--- a/lib/api_adaptor/version.rb
+++ b/lib/api_adaptor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ApiAdaptor
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
## Summary
- Bump api_adaptor to v1.0.1
- Add v1.0.1 changelog entry for dependency and CI updates
- Update Gemfile.lock path gem version to v1.0.1

## Tests
- bundle exec rspec