### PR TITLE
Release v1.0.2

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.2] - 2026-05-31
+
+### Changed
+- Removed Ruby 3.2 from CI test and lint matrices because Ruby 3.2 reached end-of-life on 2026-04-01.
+- Ruby 3.2 remains installable for this release, but runtime support will be dropped in the next major release.
+
 ## [1.0.1] - 2026-05-31
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    api_adaptor (1.0.1)
+    api_adaptor (1.0.2)
       addressable (~> 2.8)
       base64 (~> 0.3)
       bigdecimal (>= 3.3, < 5.0)

--- a/lib/api_adaptor/version.rb
+++ b/lib/api_adaptor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ApiAdaptor
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
## Summary
- Bump api_adaptor to v1.0.2
- Remove Ruby 3.2 from CI lint and test matrices after its 2026-04-01 EOL
- Keep Ruby 3.2 installable for this patch release and note it will be dropped in the next major release

## SemVer
This remains a patch release because the gemspec still permits Ruby 3.2 with `required_ruby_version >= 3.2.0`; this only changes CI coverage for an EOL runtime.

## Tests
- bundle exec rspec
- bundle exec rubocop