### PR TITLE
Opt release workflow into Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true for the release workflow
- Keeps release workflow JavaScript actions on the upcoming GitHub Actions Node runtime
- No gem version or release notes changes

## Validation
- Parsed .github/workflows/release.yml with Ruby YAML loader